### PR TITLE
Take repo under the EDCD group for safe-guarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# THIS PROJECT HAS MOVED  
+The project can now be found here:  
+https://github.com/EDCD/TCE-Relay
+
 # TCE-Relay
 Updates prices in TCE from EDDB/EDDN
 


### PR DESCRIPTION
This project is of importance to the Elite Dangerous community and with the original developer stepping away, it makes sense for it to be absorbed by EDCD.